### PR TITLE
solves issue w/ module.default.initialize

### DIFF
--- a/src/js/Components/ComponentIndex.js
+++ b/src/js/Components/ComponentIndex.js
@@ -9,9 +9,6 @@
  *
  *  This can be changed in the const module = await import(`./${path}/${path}`); directive below
  *
- * BUG ALERT: I don't yet know why but sometimes if (module.default) module.default() errs out and I have to change it
- * to module.default.initialize(); to make it work.  I don't know - I don't get it.
- *
  */
 const ComponentIndex = () => {
   const asyncModules = {
@@ -28,7 +25,7 @@ const ComponentIndex = () => {
 
         /** Load & initialize the module */
         const module = await import(`./${path}/${path}`);
-        if (module.default) module.default();
+        if (module.default) module.default.initialize();
       })
     );
   };

--- a/src/js/Components/ComponentTemplate/ComponentTemplate.js
+++ b/src/js/Components/ComponentTemplate/ComponentTemplate.js
@@ -6,7 +6,7 @@
 
 export default (() => {
   const handleTemplate = () => {
-    console.log("Im the component template");
+    console.log("Itsa me the template element!"); // eslint-disable-line no-console
   };
   const initialize = () => {
     handleTemplate();


### PR DESCRIPTION
Solved why it worked sometimes w/ module.default.initialize:  I was forgetting to copy in the component template and I was just creating a blank template before.  If you bring in the component template then you must use module.default.initialize() and it works as expected.